### PR TITLE
rewrite github as object rather than prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,18 +94,14 @@ function redirect () {
 function register() {
   // need to grab the code provided by GitHub
   var code = window.location.href.match(/\?code=(.*)/)[1]
-  var body = {
+  var json = {
     code: code
   }
   var opts = {
     // or /login to verify user info
     uri: '/register',
-    body: body,
-    json: true,
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    }
+    json: json,
+    method: 'POST'
   }
 
   xhr(opts, function (err, res, body) {

--- a/example/client.js
+++ b/example/client.js
@@ -30,12 +30,8 @@ function doneView () {
   }
   var opts = {
     uri: '/login',
-    body: body,
-    json: true,
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    }
+    json: json,
+    method: 'POST'
   }
 
   xhr(opts, function (err, res, body) {

--- a/example/client.js
+++ b/example/client.js
@@ -25,7 +25,7 @@ function mainView () {
 
 function doneView () {
   var code = window.location.href.match(/\?code=(.*)/)[1]
-  var body = {
+  var json = {
     code: code
   }
   var opts = {

--- a/example/client.js
+++ b/example/client.js
@@ -29,7 +29,7 @@ function doneView () {
     code: code
   }
   var opts = {
-    uri: '/register',
+    uri: '/login',
     body: body,
     json: true,
     method: 'POST',

--- a/example/index.js
+++ b/example/index.js
@@ -34,7 +34,9 @@ app.router([
   [ '/register', {
     'post': register
   } ],
-  [ '/login', login ]
+  [ '/login', {
+    'post': login
+  } ]
 ])
 app.listen(env.PORT)
 
@@ -59,7 +61,7 @@ function login (req, res, ctx, done) {
     var opts = {
       github: { code: json.code }
     }
-    auth.verify(opts, done)
+    auth.verify('github', opts, done)
   })
 }
 
@@ -79,4 +81,3 @@ function _parseJson (req, cb) {
     cb(null, json)
   }))
 }
-

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ var url = require('url')
 module.exports = Github
 
 function Github (opts) {
-  var ctx = {}
   opts = opts || {}
 
   assert.equal(typeof opts, 'object', 'township-github: opts should be type Object')
@@ -23,24 +22,16 @@ function Github (opts) {
   assert.equal(typeof name, 'string', 'township-github: name should be type String')
   assert.equal(typeof id, 'string', 'township-github: id should be type String')
 
-  ctx.create = create
-  ctx.verify = verify
-  ctx.oauth = oauth
-  ctx.getUser = getUser
-  ctx.provider = provider
-  ctx.create = create
-  ctx.verify = verify
-  ctx.oauth = oauth
-  ctx.getUser = getUser
-  ctx.redirect = redirect
-
-  return ctx
+  return {
+    provider: provider,
+    redirect: redirect
+  }
 
   function provider (auth, options) {
     return {
       key: 'github.username',
-      create: ctx.create,
-      verify: ctx.verify
+      create: _create,
+      verify: _verify
     }
   }
 
@@ -61,9 +52,9 @@ function Github (opts) {
     res.setHeader('x-github-oauth-redirect', redirectUrl)
   }
 
-  function create (key, opts, cb) {
+  function _create (key, opts, cb) {
     var code = opts.code
-    ctx.oauth(code, function (user) {
+    _oauth(code, function (user) {
       var res = {
         username: user.login
       }
@@ -72,9 +63,9 @@ function Github (opts) {
     })
   }
 
-  function verify (opts, cb) {
+  function _verify (opts, cb) {
     var code = opts.code
-    ctx.oauth(code, function (user) {
+    _oauth(code, function (user) {
       auth.db.get(opts.key, function (err, account) {
         if (err) return cb(err)
         cb(null, { key: account.key, github: { username: account.github.username } })
@@ -82,7 +73,7 @@ function Github (opts) {
     })
   }
 
-  function oauth (code, cb) {
+  function _oauth (code, cb) {
     var verifyOpts = {
       uri: 'https://github.com/login/oauth/access_token',
       method: 'POST'
@@ -107,11 +98,11 @@ function Github (opts) {
 
       var token = obj.access_token
 
-      ctx.getUser(token, cb)
+      _getUser(token, cb)
     })
   }
 
-  function getUser (token, cb) {
+  function _getUser (token, cb) {
     var userOpts = {
       uri: 'https://api.github.com/user',
       method: 'GET',

--- a/index.js
+++ b/index.js
@@ -64,14 +64,21 @@ function Github (opts) {
   ctx._create = function (key, opts, cb) {
     var code = opts.code
     ctx._oauth(code, function (user) {
-      cb(user)
+      var res = {
+        username: user.login
+      }
+
+      cb(null, res)
     })
   }
 
   ctx._verify = function (opts, cb) {
     var code = opts.code
     ctx._oauth(code, function (user) {
-      cb(user)
+      auth.db.get(opts.key, function (err, account) {
+        if (err) return cb(err)
+        cb(null, { key: account.key, github: { username: account.github.username } })
+      })
     })
   }
 
@@ -112,7 +119,8 @@ function Github (opts) {
       if (err) return cb(explain(err, 'township-github._getUser: pipe error'))
     })
 
-    function handler (user) {
+    function handler (obj) {
+      var user = JSON.parse(obj)
       cb(user)
     }
   }


### PR DESCRIPTION
avoids scoping issues that we were facing with township-auth; now able to hook up and return all user info properly ✨ 

@yoshuawuyts what do you think abt this?