### PR TITLE
setting township-auth directly in lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,10 @@ var db = level('users')
 var app = merry()
 
 var github = Github({
-  returnUrl: '<some-browser-url-we-control>',
   secret: '<our-secret>',
   name: 'our-app',
-  id: '<our-id>'
-})
-
-var auth = Auth(db, {
-  providers: { github: github.provider() }
+  id: '<our-id>',
+  db: db
 })
 
 app.router([
@@ -40,17 +36,17 @@ app.router([
 ])
 
 function redirect (req, res, ctx, next) {
-  var html = github.redirect(req, res)
-  next(null, html)
+  github.redirect(req, res)
+  next(null, '')
 }
 
 function register (req, res, ctx, done) {
   _parseJson(req, function (err, json) {
     if (err) return done(err)
     var opts = {
-      github: { code: json.code }
+      code: json.code
     }
-    auth.create(opts, done)
+    github.create(opts, done)
   })
 }
 
@@ -58,9 +54,9 @@ function login (req, res, ctx, done) {
   _parseJson(req, function (err, json) {
     if (err) return done(err)
     var opts = {
-      github: { code: json.code }
+      code: json.code
     }
-    auth.verify('github', opts, done)
+    github.verify(opts, done)
   })
 }
 

--- a/example/index.js
+++ b/example/index.js
@@ -1,6 +1,5 @@
 var explain = require('explain-error')
 var concat = require('concat-stream')
-var Auth = require('township-auth')
 var bankai = require('bankai')
 var merry = require('merry')
 var level = require('level')
@@ -18,12 +17,9 @@ var env = merry.env({
 
 var assets = bankai(path.join(__dirname, 'client.js'), { css: false })
 var db = level(env.DATABASE_PATH)
+env.DB = db
 var github = Github(env)
 var app = merry()
-
-var auth = Auth(db, {
-  providers: { github: github.provider }
-})
 
 app.router([
   [ '/', _merryAssets(assets.html.bind(assets)) ],
@@ -49,9 +45,9 @@ function register (req, res, ctx, done) {
   _parseJson(req, function (err, json) {
     if (err) return done(err)
     var opts = {
-      github: { code: json.code }
+      code: json.code
     }
-    auth.create(opts, done)
+    github.create(opts, done)
   })
 }
 
@@ -59,9 +55,9 @@ function login (req, res, ctx, done) {
   _parseJson(req, function (err, json) {
     if (err) return done(err)
     var opts = {
-      github: { code: json.code }
+      code: json.code
     }
-    auth.verify('github', opts, done)
+    github.verify(opts, done)
   })
 }
 


### PR DESCRIPTION
soooooo, there is an issue with verify requiring actual username value to verify the logged in account. This means, when passing opts to township-auth, we actually need to have that username ready. Since we get that username from github oauth, we might need to be verifying from within the library. Does that sort of make sense?

Basically I am trying this for now (and it works!) but it's a tiny lil bit messy and will need a some cleanup. lmk what you think of this approach @yoshuawuyts ^_^